### PR TITLE
Add support for JsonObject serialization and deserialization

### DIFF
--- a/src/main/java/io/github/eealba/jasoner/JsonObject.java
+++ b/src/main/java/io/github/eealba/jasoner/JsonObject.java
@@ -1,0 +1,21 @@
+package io.github.eealba.jasoner;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Set;
+
+public interface JsonObject {
+    Set<String> keys();
+    String getString(String key);
+    Integer getInteger(String key);
+    Boolean getBoolean(String key);
+    Long getLong(String key);
+    Double getDouble(String key);
+    Float getFloat(String key);
+    JsonObject getJsonObject(String key);
+    List<?> getJsonArray(String key);
+
+    Object get(String key);
+
+    BigDecimal getBigDecimal(String key);
+}

--- a/src/main/java/io/github/eealba/jasoner/internal/JsonObjectImpl.java
+++ b/src/main/java/io/github/eealba/jasoner/internal/JsonObjectImpl.java
@@ -1,0 +1,100 @@
+package io.github.eealba.jasoner.internal;
+
+import io.github.eealba.jasoner.JsonObject;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+
+class JsonObjectImpl implements JsonObject {
+    private final java.util.Map<String, Object> map;
+
+    JsonObjectImpl(java.util.Map<String, Object> map) {
+        this.map = map;
+    }
+
+    @Override
+    public java.util.Set<String> keys() {
+        return map.keySet();
+    }
+
+    @Override
+    public String getString(String key) {
+        return (String) get(key);
+    }
+
+    @Override
+    public Integer getInteger(String key) {
+        return (Integer) get(key);
+    }
+
+    @Override
+    public Boolean getBoolean(String key) {
+        return (Boolean) get(key);
+    }
+
+    @Override
+    public Long getLong(String key) {
+        return (Long) get(key);
+    }
+
+    @Override
+    public Double getDouble(String key) {
+        return (Double) get(key);
+    }
+
+    @Override
+    public Float getFloat(String key) {
+        return (Float) get(key);
+    }
+
+    @Override
+    public BigDecimal getBigDecimal(String key) {
+        return (BigDecimal) get(key);
+    }
+
+    @Override
+    public JsonObject getJsonObject(String key) {
+        return (JsonObject) get(key);
+    }
+
+    @Override
+    public List<?> getJsonArray(String key) {
+        return (List<?>) get(key);
+    }
+
+    @Override
+    public Object get(String key) {
+        if (key == null || key.isEmpty()) {
+            throw new IllegalArgumentException("Key cannot be null or empty");
+        }
+        Object value = map.get(key);
+        if (value != null) {
+            return value;
+        }
+        // parse the key by dot for nested objects and arrays
+        String[] keys = key.split("\\.");
+        Object current = map;
+        for (String k : keys) {
+            if (current instanceof Map map2) {
+                current = map2.get(k);
+            }else  if (current instanceof JsonObject jsonObject) {
+                current = jsonObject.get(k);
+            }else if (current instanceof List) {
+                try {
+                    int index = Integer.parseInt(k);
+                    current = ((List<?>) current).get(index);
+                } catch (NumberFormatException e) {
+                    throw new IllegalArgumentException("Invalid index: " + k, e);
+                }
+            }
+        }
+        if (current == map){
+            throw new IllegalArgumentException("Key not found: " + key);
+        }
+
+        return current;
+    }
+
+
+}

--- a/src/main/java/io/github/eealba/jasoner/internal/JsonSerializerImpl.java
+++ b/src/main/java/io/github/eealba/jasoner/internal/JsonSerializerImpl.java
@@ -16,6 +16,7 @@ package io.github.eealba.jasoner.internal;
 import io.github.eealba.jasoner.JasonerConfig;
 import io.github.eealba.jasoner.JasonerProperty;
 import io.github.eealba.jasoner.JasonerSingleVO;
+import io.github.eealba.jasoner.JsonObject;
 import io.github.eealba.jasoner.SerializationStrategy;
 
 import java.io.IOException;
@@ -117,8 +118,12 @@ class JsonSerializerImpl implements JsonSerializer {
         serializeValueData(valueDataList, writer);
         writer.append(TokenImpl.OBJECT_END);
     }
-
     private ArrayList<ValueData> valueDataList(Object entity) {
+        return JsonObject.class.isAssignableFrom(entity.getClass()) ?
+                valueDataListFromJsonObject((JsonObject) entity) : valueDataListFromEntity(entity);
+    }
+
+    private ArrayList<ValueData> valueDataListFromEntity(Object entity) {
         var valueDataList = new ArrayList<ValueData>();
         if (config.serializationStrategy() == SerializationStrategy.BOTH
                 || config.serializationStrategy() == SerializationStrategy.METHOD) {
@@ -135,6 +140,23 @@ class JsonSerializerImpl implements JsonSerializer {
                     .toList());
         }
         return valueDataList;
+    }
+    private ArrayList<ValueData> valueDataListFromJsonObject(JsonObject entity) {
+        var res = entity.keys().stream().map((String key) -> {
+            var value = entity.get(key);
+            return new ValueData(entity, null, null) {
+                @Override
+                Object getValue() {
+                    return value;
+                }
+                @Override
+                String getName(Function<String, String> namingFunction) {
+                    // Use the key directly as the name
+                    return key;
+                }
+            };
+        }).toList();
+        return new ArrayList<>(res);
     }
 
 

--- a/src/main/java/io/github/eealba/jasoner/internal/Reflects.java
+++ b/src/main/java/io/github/eealba/jasoner/internal/Reflects.java
@@ -16,6 +16,7 @@ package io.github.eealba.jasoner.internal;
 import io.github.eealba.jasoner.JasonerException;
 import io.github.eealba.jasoner.JasonerProperty;
 import io.github.eealba.jasoner.JasonerTransient;
+import io.github.eealba.jasoner.JsonObject;
 import io.github.eealba.jasoner.ModifierStrategy;
 import io.github.eealba.jasoner.NamingStrategy;
 
@@ -311,8 +312,31 @@ class Reflects {
      * @param clazz the class
      * @return an optional containing the instance, or empty if not created
      */
-    static <T> Optional<T> createObject(Class<T> clazz) {
+    static <T> Optional<T> createJsonObject(Class<T> clazz) {
         return Optional.ofNullable(clazz.cast(createObjectInt(clazz)));
+    }
+
+    /**
+     * Creates an instance of a class with the specified arguments.
+     *
+     * @param clazz the class
+     * @return an optional containing the instance, or empty if not created
+     */
+    static Optional<JsonObject> createJsonObject(Class<?> clazz, Object... args) {
+        if (!JsonObject.class.isAssignableFrom(clazz)) {
+            throw new IllegalArgumentException(String.format("The class: '%s' is not a JsonObject", clazz.getName()));
+        }
+        for (Constructor<?> c : clazz.getDeclaredConstructors()) {
+            if (c.getParameterCount() == args.length && c.trySetAccessible()) {
+                try {
+                    return Optional.of((JsonObject) (c.newInstance(args)));
+                } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+                    throw new JasonerException(e);
+                }
+            }
+        }
+        return createJsonObject(JsonObjectImpl.class, args);
+
     }
 
     private static Object createObjectInt(Class<?> clazz) {

--- a/src/test/java/io/github/eealba/example/webhooks/Event3.java
+++ b/src/test/java/io/github/eealba/example/webhooks/Event3.java
@@ -1,0 +1,225 @@
+package io.github.eealba.example.webhooks;
+
+import io.github.eealba.jasoner.JasonerProperty;
+import io.github.eealba.jasoner.JsonObject;
+
+import java.util.List;
+
+/**
+ * A webhook event notification.
+ */
+public class Event3 {
+
+
+
+    private final String id;
+    @JasonerProperty("create_time")
+    private final String createTime;
+    @JasonerProperty("resource_type")
+    private final String resourceType;
+    @JasonerProperty("event_version")
+    private final EventVersion eventVersion;
+    @JasonerProperty("event_type")
+    private final String eventType;
+
+    private final String summary;
+    @JasonerProperty("resource_version")
+    private final ResourceVersion resourceVersion;
+
+    private final JsonObject resource;
+
+    private final List<JsonObject> links;
+
+    private Event3(Builder builder) {
+        id = builder.id;
+        createTime = builder.createTime;
+        resourceType = builder.resourceType;
+        eventVersion = builder.eventVersion;
+        eventType = builder.eventType;
+        summary = builder.summary;
+        resourceVersion = builder.resourceVersion;
+        resource = builder.resource;
+        links = builder.links;
+    }
+
+    /**
+     * The ID of the webhook event notification.
+     */
+    
+    public String id() {
+        return id;
+    }
+
+    /**
+     * The date and time when the webhook event notification was created, in [Internet date and time 
+format](https://tools.ietf.org/html/rfc3339#section-5.6).
+     */
+    @JasonerProperty("create_time")
+    public String createTime() {
+        return createTime;
+    }
+
+    /**
+     * The name of the resource related to the webhook notification event.
+     */
+    @JasonerProperty("resource_type")
+    public String resourceType() {
+        return resourceType;
+    }
+
+    /**
+     * eventVersion
+     */
+    @JasonerProperty("event_version")
+    public EventVersion eventVersion() {
+        return eventVersion;
+    }
+
+    /**
+     * The event that triggered the webhook event notification.
+     */
+    @JasonerProperty("event_type")
+    public String eventType() {
+        return eventType;
+    }
+
+    /**
+     * A summary description for the event notification.
+     */
+    
+    public String summary() {
+        return summary;
+    }
+
+    /**
+     * resourceVersion
+     */
+    @JasonerProperty("resource_version")
+    public ResourceVersion resourceVersion() {
+        return resourceVersion;
+    }
+
+    /**
+     * The resource that triggered the webhook event notification.
+     */
+    
+    public JsonObject resource() {
+        return resource;
+    }
+
+    /**
+     * An array of request-related [HATEOAS links](/docs/api/reference/api-responses/#hateoas-links).
+     */
+    
+    public List<JsonObject> links() {
+        return links;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private String id;
+        private String createTime;
+        private String resourceType;
+        private EventVersion eventVersion;
+        private String eventType;
+        private String summary;
+        private ResourceVersion resourceVersion;
+        private JsonObject resource;
+        private List<JsonObject> links;
+
+        /**
+         * The ID of the webhook event notification.
+         */
+        
+        public Builder id(String value) {
+            this.id = value;
+            return this;
+        }
+
+        /**
+         * The date and time when the webhook event notification was created, in [Internet date and time 
+format](https://tools.ietf.org/html/rfc3339#section-5.6).
+         */
+        @JasonerProperty("create_time")
+        public Builder createTime(String value) {
+            this.createTime = value;
+            return this;
+        }
+
+        /**
+         * The name of the resource related to the webhook notification event.
+         */
+        @JasonerProperty("resource_type")
+        public Builder resourceType(String value) {
+            this.resourceType = value;
+            return this;
+        }
+
+        /**
+         * eventVersion
+         */
+        @JasonerProperty("event_version")
+        public Builder eventVersion(EventVersion value) {
+            this.eventVersion = value;
+            return this;
+        }
+
+        /**
+         * The event that triggered the webhook event notification.
+         */
+        @JasonerProperty("event_type")
+        public Builder eventType(String value) {
+            this.eventType = value;
+            return this;
+        }
+
+        /**
+         * A summary description for the event notification.
+         */
+        
+        public Builder summary(String value) {
+            this.summary = value;
+            return this;
+        }
+
+        /**
+         * resourceVersion
+         */
+        @JasonerProperty("resource_version")
+        public Builder resourceVersion(ResourceVersion value) {
+            this.resourceVersion = value;
+            return this;
+        }
+
+        /**
+         * The resource that triggered the webhook event notification.
+         */
+        
+        public Builder resource(JsonObject value) {
+            this.resource = value;
+            return this;
+        }
+
+        /**
+         * An array of request-related [HATEOAS links](/docs/api/reference/api-responses/#hateoas-links).
+         */
+        
+        public Builder links(List<JsonObject> value) {
+            this.links = value;
+            return this;
+        }
+
+        public Event3 build() {
+            return new Event3(this);
+        }
+
+    }
+
+
+
+}
+

--- a/src/test/java/io/github/eealba/jasoner/PaypalPayloadTest.java
+++ b/src/test/java/io/github/eealba/jasoner/PaypalPayloadTest.java
@@ -146,6 +146,10 @@ public class PaypalPayloadTest {
         executeAndCompare(readResource(EXAMPLES + "webhooks-events.resend_response.json"), Event2.class);
     }
 
+    @Test
+    void webhooks_events_resend_response_with_JsonObject() throws IOException, JSONException {
+        executeAndCompare(readResource(EXAMPLES + "webhooks-events.resend_response.json"), JsonObject.class);
+    }
 
     @Test
     void patch_serialize() throws JSONException {

--- a/src/test/java/io/github/eealba/jasoner/internal/JsonDeserializerImplTest.java
+++ b/src/test/java/io/github/eealba/jasoner/internal/JsonDeserializerImplTest.java
@@ -111,7 +111,7 @@ class JsonDeserializerImplTest {
         assertEquals("PROD-XXCD1234QWER65782", jsonObject.getString("product_id"));
     }
 
-    public static class JsonObject2 implements JsonObject {
+    static class JsonObject2 implements JsonObject {
         private final Map<String, Object> map;
         public JsonObject2(Map<String, Object> map) {
             this.map = map;

--- a/src/test/java/io/github/eealba/jasoner/internal/JsonDeserializerImplTest.java
+++ b/src/test/java/io/github/eealba/jasoner/internal/JsonDeserializerImplTest.java
@@ -5,7 +5,11 @@ import io.github.eealba.jasoner.JsonObject;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -98,6 +102,76 @@ class JsonDeserializerImplTest {
         assertEquals("PROD-XXCD1234QWER65782", jsonObject.getString("product_id"));
         assertFalse(jsonObject.getBoolean("taxes.inclusive"));
         assertEquals("3", jsonObject.getString("billing_cycles.0.pricing_scheme.fixed_price.value"));
+    }
+    @Test
+    void deserialize_with_class_that_implement_JsonObject() throws URISyntaxException, IOException {
+        String data = Helper.readResource("plan.json");
+        var jsonObject = deserialize(data, JsonObject2.class);
+
+        assertEquals("PROD-XXCD1234QWER65782", jsonObject.getString("product_id"));
+    }
+
+    public static class JsonObject2 implements JsonObject {
+        private final Map<String, Object> map;
+        public JsonObject2(Map<String, Object> map) {
+            this.map = map;
+        }
+
+        @Override
+        public Set<String> keys() {
+            return map.keySet();
+        }
+
+        @Override
+        public String getString(String key) {
+            return (String) map.get(key);
+        }
+
+        @Override
+        public Integer getInteger(String key) {
+            return (Integer) map.get(key);
+        }
+
+        @Override
+        public Boolean getBoolean(String key) {
+            return (Boolean) map.get(key);
+        }
+
+        @Override
+        public Long getLong(String key) {
+            return (Long) map.get(key);
+        }
+
+        @Override
+        public Double getDouble(String key) {
+            return (Double) map.get(key);
+        }
+
+        @Override
+        public Float getFloat(String key) {
+            return (Float) map.get(key);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public JsonObject getJsonObject(String key) {
+            return new JsonObject2((Map<String, Object>) map.get(key));
+        }
+
+        @Override
+        public List<?> getJsonArray(String key) {
+            return (List<?>) map.get(key);
+        }
+
+        @Override
+        public Object get(String key) {
+            return map.get(key);
+        }
+
+        @Override
+        public BigDecimal getBigDecimal(String key) {
+            return (BigDecimal) map.get(key);
+        }
     }
 
 

--- a/src/test/java/io/github/eealba/jasoner/internal/JsonDeserializerImplTest.java
+++ b/src/test/java/io/github/eealba/jasoner/internal/JsonDeserializerImplTest.java
@@ -1,12 +1,14 @@
 package io.github.eealba.jasoner.internal;
 
 import io.github.eealba.jasoner.JasonerProperty;
+import io.github.eealba.jasoner.JsonObject;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class JsonDeserializerImplTest {
 
@@ -88,6 +90,20 @@ class JsonDeserializerImplTest {
 
         assertEquals("P-5ML4271244454362WXNWU5NQ", res.id());
     }
+    @Test
+    void deserialize_with_JsonObject() throws URISyntaxException, IOException {
+        String data = Helper.readResource("plan.json");
+        var jsonObject = deserialize(data, JsonObject.class);
+
+        assertEquals("PROD-XXCD1234QWER65782", jsonObject.getString("product_id"));
+        assertFalse(jsonObject.getBoolean("taxes.inclusive"));
+        assertEquals("3", jsonObject.getString("billing_cycles.0.pricing_scheme.fixed_price.value"));
+    }
+
+
+
+
+
     private static <T> T deserialize(String data, Class<T> clazz) {
         JsonDeserializer deserializer = new JsonDeserializerImpl();
         return deserializer.deserialize(data, clazz);

--- a/src/test/java/io/github/eealba/jasoner/internal/JsonSerializerImplTest.java
+++ b/src/test/java/io/github/eealba/jasoner/internal/JsonSerializerImplTest.java
@@ -1,10 +1,14 @@
 package io.github.eealba.jasoner.internal;
 
+import io.github.eealba.jasoner.JsonObject;
 import io.github.eealba.jasoner.demo.model1.DemoPojo;
 import io.github.eealba.jasoner.demo.model1.DemoPojo2;
 import org.json.JSONException;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
 
 import static io.github.eealba.jasoner.internal.Helper.PACKAGE_JSON_SERIALIZER;
 import static io.github.eealba.jasoner.internal.Helper.PRIVATE_JSON_SERIALIZER;
@@ -63,6 +67,15 @@ class JsonSerializerImplTest {
     void should_serialize_object_with_modifier_public()  {
         jsonAssertEquals(JSON_PUBLIC, PUBLIC_JSON_SERIALIZER.serialize(demoPojo));
     }
+
+    @Test
+    void serialize_with_JsonObject() throws URISyntaxException, IOException {
+        String data = Helper.readResource("plan.json");
+        var jsonObject = deserialize(data, JsonObject.class);
+
+        jsonAssertEquals(data, PUBLIC_JSON_SERIALIZER.serialize(jsonObject));
+    }
+
     void jsonAssertEquals(String jsonExpected, String jsonActual) {
         try {
             System.out.println("Expected: " + jsonExpected);
@@ -72,6 +85,11 @@ class JsonSerializerImplTest {
             throw new AssertionError(e);
         }
         
+    }
+
+    private static <T> T deserialize(String data, Class<T> clazz) {
+        JsonDeserializer deserializer = new JsonDeserializerImpl();
+        return deserializer.deserialize(data, clazz);
     }
 
 }

--- a/src/test/java/io/github/eealba/jasoner/internal/ReflectsTest.java
+++ b/src/test/java/io/github/eealba/jasoner/internal/ReflectsTest.java
@@ -20,14 +20,14 @@ class ReflectsTest {
 
     @Test
     void should_return_all_methods() {
-        var plan = Reflects.createObject(io.github.eealba.jasoner.demo.model1.Plan.class).orElseThrow();
+        var plan = Reflects.createJsonObject(io.github.eealba.jasoner.demo.model1.Plan.class).orElseThrow();
         var methods = Reflects.getMethods(plan);
 
         assertTrue(methods.size() > 10);
     }
     @Test
     void should_filter__methods() {
-        var plan = Reflects.createObject(io.github.eealba.jasoner.demo.model1.Plan.class).orElseThrow();
+        var plan = Reflects.createJsonObject(io.github.eealba.jasoner.demo.model1.Plan.class).orElseThrow();
         var allMethods = Reflects.getMethods(plan);
         var methods = Reflects.getMethods(plan, (Method m) -> m.getName().contains("name"));
 
@@ -36,21 +36,21 @@ class ReflectsTest {
 
     @Test
     void should_return_all_Fields() {
-        var plan = Reflects.createObject(io.github.eealba.jasoner.demo.model1.Plan.class).orElseThrow();
+        var plan = Reflects.createJsonObject(io.github.eealba.jasoner.demo.model1.Plan.class).orElseThrow();
         var fields = Reflects.getFields(plan);
 
         assertEquals(7, fields.size());
     }
     @Test
     void should_return_Field() {
-        var plan = Reflects.createObject(io.github.eealba.jasoner.demo.model1.Plan.class).orElseThrow();
+        var plan = Reflects.createJsonObject(io.github.eealba.jasoner.demo.model1.Plan.class).orElseThrow();
         var field = Reflects.getField(plan, "name");
 
         assertTrue(field.isPresent());
     }
     @Test
     void should_set_Field_value() {
-        var plan = Reflects.createObject(io.github.eealba.jasoner.demo.model1.Plan.class).orElseThrow();
+        var plan = Reflects.createJsonObject(io.github.eealba.jasoner.demo.model1.Plan.class).orElseThrow();
         var field = Reflects.getField(plan, "name");
         field.ifPresent(value -> Reflects.setFieldValue(value, plan, "Pepe"));
 
@@ -59,12 +59,12 @@ class ReflectsTest {
 
     @Test
     void should_not_create_instance_because_private_default_constructor() {
-        var result = Reflects.createObject(io.github.eealba.jasoner.demo.model2.Plan.class);
+        var result = Reflects.createJsonObject(io.github.eealba.jasoner.demo.model2.Plan.class);
        assertFalse(result.isPresent());
     }
     @Test
     void should_create_instance_because_public_default_constructor() {
-        var result = Reflects.createObject(io.github.eealba.jasoner.demo.model1.Plan.class);
+        var result = Reflects.createJsonObject(io.github.eealba.jasoner.demo.model1.Plan.class);
         assertTrue(result.isPresent());
     }
 
@@ -103,7 +103,7 @@ class ReflectsTest {
 
     @Test
     void should_get_setter_method() {
-        var plan = Reflects.createObject(io.github.eealba.jasoner.demo.model1.Plan.class).orElseThrow();
+        var plan = Reflects.createJsonObject(io.github.eealba.jasoner.demo.model1.Plan.class).orElseThrow();
         findSetterAndVerify(plan, "name", "Hola", "setName");
         findSetterAndVerify(plan, "productId", "123", "setProductId");
         findSetterAndVerify(plan, "product_Id", "123", "setProductId");
@@ -124,7 +124,7 @@ class ReflectsTest {
 
     @Test
     void should_return_parameter_class() {
-        var plan = Reflects.createObject(io.github.eealba.jasoner.demo.model1.Plan.class).orElseThrow();
+        var plan = Reflects.createJsonObject(io.github.eealba.jasoner.demo.model1.Plan.class).orElseThrow();
         var clazz = Reflects.getSetterMethodParameterClass(plan, "payment_preferences");
 
         assertEquals(io.github.eealba.jasoner.demo.model1.PaymentPreferences.class, clazz.orElseThrow());
@@ -140,7 +140,7 @@ class ReflectsTest {
 
     @Test
     void should_return_parameter_class2() {
-        var plan = Reflects.createObject(io.github.eealba.jasoner.demo.model1.Plan.class).orElseThrow();
+        var plan = Reflects.createJsonObject(io.github.eealba.jasoner.demo.model1.Plan.class).orElseThrow();
         var clazz = Reflects.getSetterMethodParameterClass(plan, "billing_cycles");
 
         assertEquals(io.github.eealba.jasoner.demo.model1.BillingCycle.class, clazz.orElseThrow());


### PR DESCRIPTION
```
### Description
This pull request introduces support for `JsonObject` serialization and deserialization. Changes include:
- Enhanced `JsonSerializerImpl` and `JsonDeserializerImpl` to handle `JsonObject` instances.
- Added tests to ensure compatibility with dynamic JSON structures.
- Updated `ObjectCreator` and `Reflects` for `JsonObject` creation and manipulation.
- Introduced the `JsonObject` interface and its implementation `JsonObjectImpl`.

### Type of Change
- [X ] Bug fix
- [x] New feature
- [ ] Breaking change
- [X ] Documentation update
- [ ] Other 

### Related Issues
None.

### Testing
- Unit tests have been added and updated to validate serialization, deserialization, and object creation of `JsonObject`.

### Additional Notes
None.
```